### PR TITLE
fix import isbntools

### DIFF
--- a/fetcher.py
+++ b/fetcher.py
@@ -19,7 +19,7 @@ import arxiv2bib as arxiv_metadata
 import tools
 import params
 from bibtexparser.bparser import BibTexParser
-from isbntools.dev.fmt import fmtbib
+from isbntools.dev._fmt import fmtbib
 
 
 def download(url):


### PR DESCRIPTION
I have not checked if upstream recently changed the path. however, this is supposed to work with the last version.
