### PR TITLE
Have manual entry working

### DIFF
--- a/bmc.py
+++ b/bmc.py
@@ -40,7 +40,7 @@ def checkBibtex(filename, bibtex_string):
         check = tools.rawInput("Is it correct? [Y/n] ")
     except KeyboardInterrupt:
         sys.exit()
-    except (KeyError, AssertionError):
+    except (KeyError, AssertionError, IndexError):
         check = 'n'
 
     try:
@@ -54,7 +54,8 @@ def checkBibtex(filename, bibtex_string):
             tmpfile.flush()
             subprocess.call([EDITOR, tmpfile.name])
             tmpfile.seek(0)
-            bibtex = BibTexParser(tmpfile.read().decode('utf-8')+"\n")
+            bibtex = BibTexParser(open(tmpfile.name, 'r').read().decode('utf-8')+"\n")
+            print(bibtex)
 
         bibtex = bibtex.get_entry_dict()
         try:
@@ -182,8 +183,15 @@ def addFile(src, filetype, manual, autoconfirm, tag):
         bibtex = bibtex[bibtex_name]
         bibtex_string = tools.parsed2Bibtex(bibtex)
     else:
+#        with tempfile.NamedTemporaryFile(suffix=".tmp") as tmpfile:
+#            tmpfile.write('#Please input bibtex info here')
+#            tmpfile.flush()
+#            subprocess.call([EDITOR, tmpfile.name])
+#            tmpfile.seek(0)
+#            tmpfile = open(tmpfile.name, 'r')
+#            bibtex_string = tmpfile.read().decode('utf-8')+"\n"
+#            tmpfile.close()
         bibtex_string = ''
-
     if not autoconfirm:
         bibtex = checkBibtex(src, bibtex_string)
 


### PR DESCRIPTION
Take a look at the diffs and let me know what you think but here is what happens when I run it now:

```
BMC (working_on_manual_entry)$ python bmc.py import ~/Desktop/yadin_1965.pdf
DOI / arXiv / ISBN / manual / skip? manual
The bibtex entry found for /Users/vince/Desktop/yadin_1965.pdf is:
<bibtexparser.bibdatabase.BibDatabase object at 0x105f10f10>

The bibtex entry for /Users/vince/Desktop/yadin_1965.pdf is:
@article{avi1965sequence,
author={Avi-Itzhak, B and Yadin, M},
journal={Management science},
number={5},
pages={553--564},
publisher={INFORMS},
title={A sequence of two servers with no intermediate queue},
volume={11},
    year={1965},
Is it correct? [Y/n] Y
Tag for this paper (leave empty for default) ?
New name [/Users/vince/Papers/Avi-Itzhak_Yadin-Management_science-1965 (2).pdf]?
/Users/vince/Desktop/yadin_1965.pdf successfully imported as /Users/vince/Papers/Avi-Itzhak_Yadin-Management_science-1965 (2).pdf.
```

Not sure if this has broken anything else as I haven't figured out if you have a testing framework yet or not :)

Thanks for this by the way, I will definitely be using it and have a couple of ideas for other things that I might like to work on...
