### PR TITLE
Only flush the input stream before reading data

### DIFF
--- a/libbmc/tools.py
+++ b/libbmc/tools.py
@@ -15,7 +15,7 @@ import os
 import re
 import sys
 if os.name == "posix":
-    from termios import tcflush, TCIOFLUSH
+    from termios import tcflush, TCIFLUSH
 
 try:
     input = raw_input
@@ -69,7 +69,7 @@ def replaceAll(text, dic):
 def rawInput(string):
     """Flush stdin and then prompt the user for something"""
     if os.name == "posix":
-        tcflush(sys.stdin, TCIOFLUSH)
+        tcflush(sys.stdin, TCIFLUSH)
     return input(string)
 
 


### PR DESCRIPTION
In the tools.rawInput() function, using the TCIOFLUSH queue selector
seemed to be discarding data from both the stdin and stdout queues, even
though the file descriptor was set to sys.stdin. This was giving me
intermittent missing output depending on the relative timing of the
stdout queue being pushed to the screen and tcflush() emptying it. For
example, sometimes on importing I would be asked "Is this correct?"
without seeing the proposed entry because it had been flushed.

This commit changes the tcflush() call to use TCIFLUSH to only empty the
input queue. It makes the output reliable on my system.
