### PR TITLE
Remove leading/trailing whitespace from extracted DOI

### DIFF
--- a/libbmc/fetcher.py
+++ b/libbmc/fetcher.py
@@ -265,7 +265,7 @@ def findArticleID(src, only=["DOI", "arXiv"]):
                     if cleanDOItemp[i].isalpha() and digitStart:
                         break
             cleanDOI = cleanDOI[0:(8+i)]
-        return ("DOI", cleanDOI)
+        return ("DOI", cleanDOI.strip())
     elif extractID is not None and extract_type == "arXiv":
         # If arXiv id is extracted, return it
         return ("arXiv", extractID.group(1))


### PR DESCRIPTION
I had an issue with an automatically extracted DOI where there was leading and trailing whitespace, and as a result the BibTeX entry for it could not be automatically retrieved. A simple strip() call takes care of that.
