### PR TITLE
Normalise author names

### DIFF
--- a/bmc.py
+++ b/bmc.py
@@ -59,6 +59,7 @@ def checkBibtex(filename, bibtex_string):
             bibtex = bibtexparser.loads(tmpfile.read().decode('utf-8')+"\n")
 
         bibtex = bibtex.entries_dict
+
         try:
             bibtex = bibtex[list(bibtex.keys())[0]]
         except (IndexError, KeyError):
@@ -66,12 +67,15 @@ def checkBibtex(filename, bibtex_string):
             bibtex_string = ''
             tools.rawInput("Press Enter to go back to editor.")
             continue
-        if('authors' not in bibtex and 'title' not in bibtex and 'year' not in
+        if('author' not in bibtex and 'title' not in bibtex and 'year' not in
            bibtex):
             tools.warning("Invalid bibtex entry")
             bibtex_string = ''
             tools.rawInput("Press Enter to go back to editor.")
             continue
+
+        if 'author' in bibtex:
+            bibtex['author'] = backend.normaliseAuthors(bibtex['author'])
 
         if old_filename is not False and 'file' not in bibtex:
             tools.warning("Invalid bibtex entry. No filename given.")
@@ -182,6 +186,8 @@ def addFile(src, filetype, manual, autoconfirm, tag, rename=True):
     if len(bibtex) > 0:
         bibtex_name = list(bibtex.keys())[0]
         bibtex = bibtex[bibtex_name]
+        if 'author' in bibtex:
+            bibtex['author'] = backend.normaliseAuthors(bibtex['author'])
         bibtex_string = tools.parsed2Bibtex(bibtex)
     else:
         bibtex_string = ''

--- a/bmc.py
+++ b/bmc.py
@@ -75,7 +75,7 @@ def checkBibtex(filename, bibtex_string):
             continue
 
         if 'author' in bibtex:
-            bibtex['author'] = backend.normaliseAuthors(bibtex['author'])
+            bibtex['author'] = backend.normalizeAuthors(bibtex['author'])
 
         if old_filename is not False and 'file' not in bibtex:
             tools.warning("Invalid bibtex entry. No filename given.")
@@ -187,7 +187,7 @@ def addFile(src, filetype, manual, autoconfirm, tag, rename=True):
         bibtex_name = list(bibtex.keys())[0]
         bibtex = bibtex[bibtex_name]
         if 'author' in bibtex:
-            bibtex['author'] = backend.normaliseAuthors(bibtex['author'])
+            bibtex['author'] = backend.normalizeAuthors(bibtex['author'])
         bibtex_string = tools.parsed2Bibtex(bibtex)
     else:
         bibtex_string = ''

--- a/libbmc/backend.py
+++ b/libbmc/backend.py
@@ -26,7 +26,7 @@ def normaliseAuthors(author_str):
     """Attempt to normalise author names in last, first format.
 
     """
-    raw_authors = author_str.split('and')
+    raw_authors = author_str.split(' and ')
     authors = []
 
     for author in raw_authors:

--- a/libbmc/backend.py
+++ b/libbmc/backend.py
@@ -22,8 +22,8 @@ from codecs import open
 config = Config()
 
 
-def normaliseAuthors(author_str):
-    """Attempt to normalise author names in last, first format.
+def normalizeAuthors(author_str):
+    """Attempt to normalize author names in last, first format.
 
     """
     raw_authors = author_str.split(' and ')
@@ -64,7 +64,7 @@ def normaliseAuthors(author_str):
         else:
             authors.append(last)
 
-    # And normalised.
+    # And normalized.
     return ' and '.join(authors)
 
 

--- a/libbmc/backend.py
+++ b/libbmc/backend.py
@@ -22,6 +22,52 @@ from codecs import open
 config = Config()
 
 
+def normaliseAuthors(author_str):
+    """Attempt to normalise author names in last, first format.
+
+    """
+    raw_authors = author_str.split('and')
+    authors = []
+
+    for author in raw_authors:
+        # Already has a comma; assume it has been put in the
+        # last, first form correctly.
+        if ',' in author:
+            authors.append(author.strip())
+            continue
+
+        names = [s.strip() for s in author.split()]
+
+        # Only one name; nothing to do.
+        if len(names) == 1:
+            authors.append(names[0])
+            continue
+
+        # Search for a 'von' part -- something starting with a lowercase letter.
+        index = None
+        for i in range(len(names)):
+            if names[i][0].islower():
+                index = i
+                break
+
+        # If no von part found, assume the last name is the single surname.
+        if index is None:
+            index = -1
+
+        # Generate two pieces.
+        first = ' '.join(names[:index])
+        last = ' '.join(names[index:])
+
+        # And the overall output.
+        if first:
+            authors.append(last + ', ' + first)
+        else:
+            authors.append(last)
+
+    # And normalised.
+    return ' and '.join(authors)
+
+
 def getNewName(src, bibtex, tag='', override_format=None):
     """
     Return the formatted name according to config for the given


### PR DESCRIPTION
The retrieved metadata for some papers has the authors as "First Last". Although BibTeX handles this, other BMC functions (e.g., the %f and %l tags in the rename masks) expect "Last, First" and hence don't work.

This pull request adds a backend.normaliseAuthors() function which takes an author string and attempts to normalise each name as "Last, First". It handles 'von' style names, e.g., "Ludwig von Beethoven" or "Charles Louis Xavier Joseph de la Vallee Poussin". It currently does not handle prefixes such as Jr., III etc.

For example, the retrieved metadata for DOI 10.1109/joe.2011.2160471 has the author names as "Neil Wachowski and Mahmood R. Azimi-Sadjadi". After this pull request, these are normalised to "Wachowski, Neil and Azimi-Sadjadi, Mahmood R."
